### PR TITLE
fix(Masque): 在 Masque 按钮注册逻辑中显式传递 Cooldown 和 ChargeCooldown 以完善对Masque扁平矩形图标材质的支持

### DIFF
--- a/Style/Masque.lua
+++ b/Style/Masque.lua
@@ -41,7 +41,11 @@ function MasqueIntegration:RegisterButton(button, icon, border)
 
     -- 注册到 Masque
     local buttonData = {
-        Icon = icon,
+        Icon = icon or button.Icon,
+        -- CDFlow 注册给 Masque 的主体是 Frame，strict 模式下不会自动发现冷却区域。
+        -- 因此必须显式传递 Cooldown/ChargeCooldown，皮肤的 Cooldown 层才能生效。
+        Cooldown = button.Cooldown or button.cooldown,
+        ChargeCooldown = button.chargeCooldown or button.ChargeCooldown,
     }
 
     -- 如果有边框,也注册边框(作为 Normal 纹理)


### PR DESCRIPTION
- 此前 CDFlow 在使用 Masque Squat 等扁平矩形图标材质时，冷却刷的背景仍然是正方形，产生截图中的错配现象。<img width="85" height="67" alt="image" src="https://github.com/user-attachments/assets/dbfcac6e-37a6-48b2-afb5-c140aab7e0cf" />
- 出现这种现象具体的原因在于 CDFlow 的图标容器是 `CreateFrame("Frame", nil, ...)` 而不是 Button；Masque 在处理时会对这种对象走 strict 模式，从而不再自动扫描其他字段。而 `CDFlow/Style/Masque.lua` 的 `RegisterButton()` 只传递了 icon，没有显式传递 cooldown。所以导致的结果是：图标虽然按 Squat 皮肤变成了扁平矩形，但冷却刷 cooldown 仍按原始的正方形 CooldownFrame 绘制。
- 修复方式是在 Masque 注册时显式地同时传递 icon、cooldown 和 chargeCooldown 字段。